### PR TITLE
Generalize Module Variables

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This will define a `A` resource record for `www.example.com` as an alias of the 
 module "production_www" {
   source          = "git::https://github.com/cloudposse/tf_vanity?ref=tags/0.2.0"
   aliases         = ["www.example.com.", "static1.cdn.example.com.", "static2.cdn.example.com"]
-  zone_id         = "${var.parent_zone_id}"
+  parent_zone_id         = "${var.parent_zone_id}"
   target_dns_name = "${aws_elb.example.dns_name}"
   target_zone_id  = "${aws_elb.example.zone_id}"
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This will define a `A` resource record for `www.example.com` as an alias of the 
 ```
 module "production_www" {
   source          = "git::https://github.com/cloudposse/tf_vanity?ref=tags/0.2.0"
-  name            = "www.example.com."
+  aliases         = ["www.example.com.", "static1.cdn.example.com.", "static2.cdn.example.com"]
   zone_id         = "${var.parent_zone_id}"
   target_dns_name = "${aws_elb.example.dns_name}"
   target_zone_id  = "${aws_elb.example.zone_id}"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This will define a `A` resource record for `www.example.com` as an alias of the 
 module "production_www" {
   source          = "git::https://github.com/cloudposse/tf_vanity?ref=master"
   aliases         = ["www.example.com.", "static1.cdn.example.com.", "static2.cdn.example.com"]
-  parent_zone_id         = "${var.parent_zone_id}"
+  parent_zone_id  = "${var.parent_zone_id}"
   target_dns_name = "${aws_elb.example.dns_name}"
   target_zone_id  = "${aws_elb.example.zone_id}"
 }
@@ -30,6 +30,8 @@ module "production_www" {
 
 ## Outputs
 
-| Name       | Description               |
-|:---------- |:--------------------------|
-| `hostname` | List of DNS-records       |
+| Name               | Description                                    |
+|:------------------ |:-----------------------------------------------|
+| `hostname`         | List of DNS-records                            |
+| `parent_zone_id`   | ID of the hosted zone to contain this record   |
+| `parent_zone_name` | Name of the hosted zone to contain this record |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# tf-vanity
+# tf_vanity
+
+Terraform Module to that implements "vanity" host names (e.g. `brand.com`) as `ALIAS` records to a another Route53 DNS resource record (e.g. ELB/ALB, or CloudFront Distribution).
+
+## Usage
+
+# Define www host
+
+This will define a `A` resource record for `www.example.com` as an alias of the `aws_elb.example.dns_name`. 
+
+```
+module "production_www" {
+  source          = "git::https://github.com/cloudposse/tf_vanity?ref=tags/0.2.0"
+  name            = "www.example.com."
+  zone_id         = "${var.parent_zone_id}"
+  target_dns_name = "${aws_elb.example.dns_name}"
+  target_zone_id  = "${aws_elb.example.zone_id}"
+}
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ module "production_www" {
 |  Name                     |  Default   |  Description                                                                            | Required |
 |:--------------------------|:----------:|:----------------------------------------------------------------------------------------|:--------:|
 | `aliases`                 | `[]`       | List of aliases                                                                         | Yes      |
-| `zone_id`                 | ``         | ID of the hosted zone to contain this record                                            | Yes      |
+| `parent_zone_id`          | ``         | ID of the hosted zone to contain this record  (or specify `parent_zone_name`)           | Yes      |
+| `parent_zone_name`        | ``         | Name of the hosted zone to contain this record (or specify `parent_zone_id`)            | Yes      |
 | `target_dns_name`         | ``         | DNS-name of target resource (e.g. ALB,ELB)                                              | Yes      |
 | `target_zone_id`          | ``         | ID of target resource (e.g. ALB,ELB)                                                    | Yes      |
 | `evaluate_target_health`  | `false`    | Set to true if you want Route 53 to determine whether to respond to DNS queries         | No       |

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Terraform Module to that implements "vanity" host names (e.g. `brand.com`) as `A
 
 ## Usage
 
-# Define www host
-
 This will define a `A` resource record for `www.example.com` as an alias of the `aws_elb.example.dns_name`. 
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tf_vanity
 
-Terraform Module to that implements "vanity" host names (e.g. `brand.com`) as `ALIAS` records to a another Route53 DNS resource record (e.g. ELB/ALB, or CloudFront Distribution).
+Terraform Module that implements "vanity" host names (e.g. `brand.com`) as `ALIAS` records to an another Route53 DNS resource record (e.g. ELB/ALB, or CloudFront Distribution).
 
 ## Usage
 
@@ -8,7 +8,7 @@ This will define a `A` resource record for `www.example.com` as an alias of the 
 
 ```terraform
 module "production_www" {
-  source          = "git::https://github.com/cloudposse/tf_vanity?ref=master"
+  source          = "git::https://github.com/cloudposse/tf_vanity.git?ref=master"
   aliases         = ["www.example.com.", "static1.cdn.example.com.", "static2.cdn.example.com"]
   parent_zone_id  = "${var.parent_zone_id}"
   target_dns_name = "${aws_elb.example.dns_name}"

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,8 @@ resource "aws_route53_record" "default" {
   type    = "A"
 
   alias {
-    name                   = "${var.elb_dns_name}"
-    zone_id                = "${var.elb_zone_id}"
+    name                   = "${var.target_dns_name}"
+    zone_id                = "${var.target_zone_id}"
     evaluate_target_health = "${var.evaluate_target_health}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 resource "aws_route53_record" "default" {
+  count   = "${length(var.aliases)}"
   zone_id = "${var.zone_id}"
-  name    = "${var.name}"
+  name    = "${var.aliases[count.index]}"
   type    = "A"
 
   alias {

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_route53_zone" "parent_by_zone_name" {
 }
 
 resource "aws_route53_record" "default" {
-  count   = "${length(var.aliases)}"
+  count   = "${length(compact(var.aliases))}"
   zone_id = "${null_resource.parent.triggers.zone_id}"
   name    = "${var.aliases[count.index]}"
   type    = "A"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,27 @@
+resource "null_resource" "parent" {
+  triggers = {
+    zone_id   = "${format("%v", length(var.parent_zone_id) > 0 ? join(" ", data.aws_route53_zone.parent_by_zone_id.*.zone_id) : join(" ", data.aws_route53_zone.parent_by_zone_name.*.zone_id) )}"
+    zone_name = "${format("%v", length(var.parent_zone_id) > 0 ? join(" ", data.aws_route53_zone.parent_by_zone_id.*.name) : join(" ", data.aws_route53_zone.parent_by_zone_name.*.name) )}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "parent_by_zone_id" {
+  count   = "${signum(length(var.parent_zone_id))}"
+  zone_id = "${var.parent_zone_id}"
+}
+
+data "aws_route53_zone" "parent_by_zone_name" {
+  count = "${signum(length(var.parent_zone_name))}"
+  name  = "${var.parent_zone_name}"
+}
+
 resource "aws_route53_record" "default" {
   count   = "${length(var.aliases)}"
-  zone_id = "${var.zone_id}"
+  zone_id = "${null_resource.parent.triggers.zone_id}"
   name    = "${var.aliases[count.index]}"
   type    = "A"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "hostname" {
-  value = "${aws_route53_record.default.fqdn}"
+  value = "${aws_route53_record.default.*.fqdn}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "hostname" {
+output "hostnames" {
   value = "${aws_route53_record.default.*.fqdn}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,13 @@
 output "hostname" {
   value = "${aws_route53_record.default.*.fqdn}"
 }
+
+output "parent_zone_id" {
+  value = "${null_resource.parent.triggers.zone_id}"
+}
+
+output "parent_zone_name" {
+  value = "${null_resource.parent.triggers.zone_name}"
+}
+
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,5 +9,3 @@ output "parent_zone_id" {
 output "parent_zone_name" {
   value = "${null_resource.parent.triggers.zone_name}"
 }
-
-

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
-variable "name" {
-  default = "dns"
+variable "aliases" {
+  type = "list"
 }
 
 variable "zone_id" {}

--- a/variables.tf
+++ b/variables.tf
@@ -4,9 +4,9 @@ variable "name" {
 
 variable "zone_id" {}
 
-variable "elb_dns_name" {}
+variable "target_dns_name" {}
 
-variable "elb_zone_id" {}
+variable "target_zone_id" {}
 
 variable "evaluate_target_health" {
   default = "false"

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,13 @@ variable "aliases" {
   type = "list"
 }
 
-variable "zone_id" {}
+variable "parent_zone_id" {
+  default = ""
+}
+
+variable "parent_zone_name" {
+  default = ""
+}
 
 variable "target_dns_name" {}
 


### PR DESCRIPTION
## what
* Generalize module variables
* Support a list of aliases (e.g. `["static1.cdn", "static2.cdn", "static3.cdn"]`, etc.)
* Update docs
* Update license

## why
* Module is applicable to all kinds of targets in Route53 (e.g. CloudFront distributions)